### PR TITLE
Don't read POST_BODY if content_type is nil.

### DIFF
--- a/lib/rack/parser.rb
+++ b/lib/rack/parser.rb
@@ -62,9 +62,9 @@ module Rack
     end
 
     def _call(env)
-      body = env[POST_BODY].read
-      return @app.call(env) if (body.respond_to?(:empty?) ? body.empty? : !body) # Send it down the stack immediately
       content_type = Rack::Request.new(env).media_type
+      body = env[POST_BODY].read if content_type
+      return @app.call(env) if (body.respond_to?(:empty?) ? body.empty? : !body) # Send it down the stack immediately
       begin
         result = @content_types[content_type].call(body)
         env.update FORM_HASH => result, FORM_INPUT => env[POST_BODY]


### PR DESCRIPTION
I had an issue running with jruby-rack/winstone where the rack-parser's POST_BODY read was timing out on a GET request with no body.  I'm not entirely sure the problem isn't in jruby-rack or winstone, but I fixed it by having rack-parser only read the body if content_type is non-nil (which allows for GET requests with bodies).
