### PR TITLE
small fix for a unconcerned content type

### DIFF
--- a/lib/rack/parser.rb
+++ b/lib/rack/parser.rb
@@ -63,6 +63,7 @@ module Rack
 
     def _call(env)
       content_type = Rack::Request.new(env).media_type
+      return @app.call(env) if !@content_types[content_type] && !@error_responses[content_type]
       body = env[POST_BODY].read if content_type
       return @app.call(env) if (body.respond_to?(:empty?) ? body.empty? : !body) # Send it down the stack immediately
       begin

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -82,4 +82,13 @@ context "Rack::Parser" do
     asserts(:body).matches %r{Hello world}
   end
 
+  context "for get with unconcerned content_type" do
+    setup do
+      post '/post', 'foo=bar', { 'CONTENT_TYPE' => 'application/x-www-form-urlencoded' }
+    end
+
+    asserts(:status).equals 200
+    asserts(:body).equals({'foo' => 'bar'}.inspect)
+  end
+
 end


### PR DESCRIPTION
Send it down the stack immediately if given content-type should not be handled by rack-parser(especially application/x-www-form-urlencoded)
