### PR TITLE
Security: Bump multi_xml version to 0.5.2

### DIFF
--- a/rack-parser.gemspec
+++ b/rack-parser.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rack'
   s.add_dependency 'multi_json'
-  s.add_dependency 'multi_xml'
+  s.add_dependency 'multi_xml', '>= 0.5.2'
   s.add_development_dependency 'riot'
   s.add_development_dependency 'rack-test'
   s.add_development_dependency 'json'


### PR DESCRIPTION
Rack::Parser is vulnerable to a vulnerability that allows remote code execution similar to Rails one detailed in CVE-2013-0156. To fix it is necessary bump multi_xml version and release a new version of library.
