### PR TITLE
Don't catch upstream errors.

### DIFF
--- a/lib/rack/parser.rb
+++ b/lib/rack/parser.rb
@@ -69,12 +69,12 @@ module Rack
       begin
         result = @content_types[content_type].call(body)
         env.update FORM_HASH => result, FORM_INPUT => env[POST_BODY]
-        @app.call env
       rescue Exception => e
         logger.warn "#{self.class} #{content_type} parsing error: #{e.to_s}" if respond_to? :logger # Send to logger if its there.
         err = @error_responses[content_type] ? content_type : 'default'
-        @error_responses[err].call(e, content_type) # call the error responses
+        return @error_responses[err].call(e, content_type) # call the error responses
       end
+      @app.call env
     end
 
   end

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -91,4 +91,10 @@ context "Rack::Parser" do
     asserts(:body).equals({'foo' => 'bar'}.inspect)
   end
 
+  context "for upstream errors" do
+    asserts('/error') do
+      post '/error', '{}', { 'CONTENT_TYPE' => 'application/json' }
+    end.raises(Exception, 'OOOPS!!')
+  end
+
 end

--- a/test/teststrap.rb
+++ b/test/teststrap.rb
@@ -17,6 +17,8 @@ class Riot::Situation
       when '/' then [200,'Hello world']
       when '/post'
         [200,  Rack::Request.new(env).params]
+      when '/error'
+        raise Exception, 'OOOPS!!'
       else
         [404,'Nothing here']
       end


### PR DESCRIPTION
This app should only catch post-body parsing errors.  If another Rack
app raises an error while processing the request, let the error
propagate downstream to be handled by some other Rack app.
