### PR TITLE
Don't catch Exception (type)

### DIFF
--- a/lib/rack/parser.rb
+++ b/lib/rack/parser.rb
@@ -30,7 +30,7 @@ module Rack
       begin
         parsed = parser.last.call body
         env.update FORM_HASH => parsed, FORM_INPUT => env[POST_BODY]
-      rescue Exception => e
+      rescue StandardError => e
         warn! e, type
         handler   = handlers.detect { |content_type, _|  type.match(content_type) }
         handler ||= ['default', ERROR_HANDLER]


### PR DESCRIPTION
Instead catch StandardError (which should be the parent type of
any exceptions being raised from various parsers).
