### PR TITLE
Preserve option fields after setup

### DIFF
--- a/lib/rack/parser.rb
+++ b/lib/rack/parser.rb
@@ -12,9 +12,9 @@ module Rack
 
     def initialize(app, options = {})
       @app      = app
-      @parsers  = options.delete(:parsers)  || { %r{json} => JSON_PARSER }
-      @handlers = options.delete(:handlers) || {}
-      @logger   = options.delete(:logger)
+      @parsers  = options[:parsers]  || { %r{json} => JSON_PARSER }
+      @handlers = options[:handlers] || {}
+      @logger   = options[:logger]
     end
 
     def call(env)

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -7,6 +7,12 @@ describe Rack::Parser do
     assert_equal 'bar', middleware.parsers['foo']
   end
 
+  it "should not remove fields from options in setup" do
+    options = {:parsers => { 'foo' => 'bar' }}
+    middleware = Rack::Parser.new ParserApp, options
+    refute_nil options[:parsers]
+  end
+
   it "allows you to setup error handlers" do
     stack = Rack::Parser.new ParserApp, :handlers => { 'foo' => 'bar' } 
     assert_equal 'bar', stack.handlers['foo']


### PR DESCRIPTION
Current implementation of rack-parser would remove `:parsers`, `:handlers` and `:logger` fields after initialization.

While this might be okay for situations that uses `dup` to create multiple app instances, it might bring problems if we are re-initializing the app instance from scratch again(like in tests).

So, is there any particular reasons that `delete` is used here? If not, can we remove the use of `delete` here?