### PR TITLE
Make regex matching explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ http://www.mikeperham.com/2012/03/03/the-perils-of-rescue-exception/
 With version `0.4.0`, you can specify regex matches for the content
 types that you want the `parsers` and `handlers` to match.
 
+NOTE: you need to explicitly pass a `Regexp` for it to regex match.
+
 ```ruby
 parser  = proc { |data| JSON.parse data }
 handler = proc { |e, type| [400, {}, 'boop'] }

--- a/lib/rack/parser.rb
+++ b/lib/rack/parser.rb
@@ -20,7 +20,7 @@ module Rack
 
     def call(env)
       type   = Rack::Request.new(env).media_type
-      parser = parsers.detect { |content_type, _| type.match(content_type) } if type
+      parser = match_content_types_for(parsers, type) if type
       return @app.call(env) unless parser
       body = env[POST_BODY].read ; env[POST_BODY].rewind
       return @app.call(env) unless body && !body.empty?
@@ -30,7 +30,7 @@ module Rack
         env.update FORM_HASH => parsed, FORM_INPUT => env[POST_BODY] if parsed.is_a?(Hash)
       rescue StandardError => e
         warn! e, type
-        handler   = handlers.detect { |content_type, _|  type.match(content_type) }
+        handler   = match_content_types_for handlers, type
         handler ||= ['default', ERROR_HANDLER]
         return handler.last.call(e, type)
       end
@@ -46,6 +46,18 @@ module Rack
       return unless logger
       message = "[Rack::Parser] Error on %s : %s" % [type, error.to_s]
       logger.warn message
+    end
+
+    # Private: matches content types for the given media type
+    #
+    # content_types - An array of the parsers or handlers options
+    # type          - The media type. gathered from the Rack::Request
+    #
+    # Returns The match from the parser/handler hash or nil
+    def match_content_types_for(content_types, type)
+      content_types.detect do |content_type, _|
+        content_type.is_a?(Regexp) ? type.match(content_type) : type == content_type
+      end
     end
   end
 end


### PR DESCRIPTION
This should fix #15 and make it necessary to explicitly set `Regexp` objects to use regex matching in the `parsers` or `handlers` portion.