### PR TITLE
Fix compatibility with Rack 3.1+

### DIFF
--- a/lib/rack/parser.rb
+++ b/lib/rack/parser.rb
@@ -22,6 +22,8 @@ module Rack
       type   = Rack::Request.new(env).media_type
       parser = match_content_types_for(parsers, type) if type
       return @app.call(env) unless parser
+      # rack.input is optional in Rack 3.1+
+      return @app.call(env) unless env[POST_BODY]
       body = env[POST_BODY].read ; env[POST_BODY].rewind
       return @app.call(env) unless body && !body.empty?
       begin


### PR DESCRIPTION
rack.input was made optional in this [PR](https://github.com/rack/rack/pull/2018/files), which landed in 3.1.
That broke rack-parser which always expects it to be present. This gracefully handles cases where it's not.
